### PR TITLE
Clarify mass and year (based on student feedback)

### DIFF
--- a/utfasning_freoner.ipynb
+++ b/utfasning_freoner.ipynb
@@ -122,7 +122,7 @@
    "source": [
     "### b)\n",
     "\n",
-    "Detta är högre än massan 1989. Förklara hur detta kan ske?"
+    "Detta är högre än massan i slutet av 1989. Förklara hur detta kan ske?"
    ]
   },
   {


### PR DESCRIPTION
Small clarification about the year (some students were confused whether the "starting" year should be 1989 or 1990).